### PR TITLE
fix (navbar): lock scrolling when mobile navbar opened

### DIFF
--- a/components/Navbar/Mobile/index.vue
+++ b/components/Navbar/Mobile/index.vue
@@ -20,12 +20,14 @@
     <NavbarMobileList
       v-show="showList"
       :menus="navigationMenus"
+      @closeList="showList = false"
     />
   </nav>
 </template>
 
 <script>
 import { navigationMenus } from '@/static/data'
+import { lockScroll } from '~/utils/browser'
 
 export default {
   data() {
@@ -37,6 +39,11 @@ export default {
   computed: {
     menuIcon() {
       return this.showList ? 'close': 'menu'
+    }
+  },
+  watch: {
+    showList() {
+      lockScroll(this.showList)
     }
   }
 }

--- a/utils/browser.js
+++ b/utils/browser.js
@@ -1,0 +1,24 @@
+
+/**
+ * Prevent page <body> tag from scrolling
+ * @param {Boolean} bool - true to prevent scrolling, false to allow
+ */
+export function lockScroll (bool) {
+  if (bool) {
+    document.body.style.top = `-${window.scrollY}px`
+    document.body.style.position = 'fixed'
+    document.body.style.width = '100%'
+    document.body.style.height = '100%'
+    document.body.style.overflowY = 'scroll'
+    document.body.style.overscrollBehavior = 'contain'
+  } else {
+    const scrollY = document.body.style.top
+    document.body.style.position = ''
+    document.body.style.width = ''
+    document.body.style.height = ''
+    document.body.style.overflowY = ''
+    document.body.style.overscrollBehavior = ''
+    document.body.style.top = ''
+    window.scrollTo(0, parseInt(scrollY || '0') * -1)
+  }
+}


### PR DESCRIPTION
## Overview
- lock scrolling when mobile navbar opened

## Evidence
title: lock scrolling when mobile navbar opened
project: Al Jabbar
participants: @naufalihsank @yoslie @agunghide 