### PR TITLE
chore: add python3 make g++ in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:lts-alpine3.16
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /app
 
 COPY package*.json ./


### PR DESCRIPTION
## Overview
- chore: add python3 make g++ in dockerfile

## Evidence
title: chore: add python3 make g++ in dockerfile
project: Digitalisasi Al Jabbar
participants: @adzharamrullah @feriahmad 